### PR TITLE
map_box_place_search_widget: Do not call on null

### DIFF
--- a/lib/src/map_box_place_search_widget.dart
+++ b/lib/src/map_box_place_search_widget.dart
@@ -103,8 +103,8 @@ class _MapBoxPlaceSearchWidgetState extends State<MapBoxPlaceSearchWidget>
 
   @override
   void dispose() {
-    _debounceTimer.cancel();
-    _animationController.dispose();
+    _debounceTimer?.cancel();
+    _animationController?.dispose();
     super.dispose();
   }
 


### PR DESCRIPTION
_debounceTimer has the value null when the search bar was not clicked. When you call `Navigator.of(context).pop()` (for example with a BackButton on an AppBar) and the dispose() function tries to cancel the timer, it will show an error in the logs.